### PR TITLE
fix regex replace that wasn't avoiding URL replaces

### DIFF
--- a/search/src/App.vue
+++ b/search/src/App.vue
@@ -177,7 +177,7 @@
 
           try {
             highlightedRenderedContent = highlightedRenderedContent.replace(
-              new RegExp(word + '(?![^<]\\*?>)', "g"), // do not replace in url within link tags i.e. <a href="url"></a>
+              new RegExp(word + '(?![^<]*?>)', "g"), // do not replace in url within link tags i.e. <a href="url"></a>
               `<em class="${cssClass}">${word}</em>`
             );
           } catch(err) {


### PR DESCRIPTION
Not sure why the regex had `\\` but that seems wrong

See an example of the issue here:
https://doc.us1.staging.dog/?facets=&q=mortar-api
every link URL was getting replaced with the highlight